### PR TITLE
Uniform FrameTask and RelativeFrameTask declaration with contacts.h fwd declarations

### DIFF
--- a/src/placo/dynamics/frame_task.h
+++ b/src/placo/dynamics/frame_task.h
@@ -5,8 +5,9 @@
 
 namespace placo::dynamics
 {
-struct FrameTask
+class FrameTask
 {
+public:
   /**
    * @brief see \ref placo::dynamics::DynamicsSolver::add_frame_task
    */

--- a/src/placo/dynamics/relative_frame_task.h
+++ b/src/placo/dynamics/relative_frame_task.h
@@ -6,8 +6,9 @@
 
 namespace placo::dynamics
 {
-struct RelativeFrameTask
+class RelativeFrameTask
 {
+public:
   /**
    * @brief see \ref placo::dynamics::DynamicsSolver::add_relative_frame_task
    */


### PR DESCRIPTION
`FrameTask` and `RelativeFrameTask` are forward declared as class in https://github.com/Rhoban/placo/blob/a983ce7bbb7233226a592a6b27a7ab35d6d5086a/src/placo/dynamics/contacts.h#L10-L13, but they are actually defined as `struct`. To cleanup this and uniform with other tasks, this PR changes them to be `class`.