### PR TITLE
Fix support for Eigen 5 while keep compatibility with Eigen 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_L
 endif()
 
 
-find_package (Eigen3 3 REQUIRED NO_MODULE)
+find_package (Eigen3 REQUIRED NO_MODULE)
 
 add_library(libplaco SHARED
     # Wrappers

--- a/src/placo/kinematics/wheel_task.cpp
+++ b/src/placo/kinematics/wheel_task.cpp
@@ -1,6 +1,12 @@
 #include "placo/kinematics/wheel_task.h"
 #include "placo/kinematics/kinematics_solver.h"
 
+if defined(EIGEN_VERSION_AT_LEAST) && EIGEN_VERSION_AT_LEAST(5, 0, 0)
+#define PLACO_KINEMATICS_WHEEL_TASK_ALL Eigen::placeholders::all
+#else
+#define PLACO_KINEMATICS_WHEEL_TASK_ALL Eigen::all
+#endif
+
 namespace placo::kinematics
 {
 WheelTask::WheelTask(std::string joint, double radius, bool omniwheel)
@@ -39,8 +45,8 @@ void WheelTask::update()
   // With an omniwheel, we remove the lateral sliding constraint (along contact y axis)
   if (omniwheel)
   {
-    Eigen::MatrixXd new_A = A({ 0, 2 }, Eigen::all);
-    Eigen::MatrixXd new_b = b({ 0, 2 }, Eigen::all);
+    Eigen::MatrixXd new_A = A({ 0, 2 }, PLACO_KINEMATICS_WHEEL_TASK_ALL);
+    Eigen::MatrixXd new_b = b({ 0, 2 }, PLACO_KINEMATICS_WHEEL_TASK_ALL);
     A = new_A;
     b = new_b;
   }

--- a/src/placo/tools/axises_mask.cpp
+++ b/src/placo/tools/axises_mask.cpp
@@ -1,6 +1,13 @@
 #include "placo/tools/axises_mask.h"
 #include <stdexcept>
 
+
+if defined(EIGEN_VERSION_AT_LEAST) && EIGEN_VERSION_AT_LEAST(5, 0, 0)
+#define PLACO_TOOLS_AXISES_MASK_ALL Eigen::placeholders::all
+#else
+#define PLACO_TOOLS_AXISES_MASK_ALL Eigen::all
+#endif
+
 namespace placo::tools
 {
 AxisesMask::AxisesMask()
@@ -76,6 +83,6 @@ Eigen::MatrixXd AxisesMask::apply(Eigen::MatrixXd M)
     M_masked = M;
   }
 
-  return M_masked(indices, Eigen::all);
+  return M_masked(indices, PLACO_TOOLS_AXISES_MASK_ALL);
 }
 }  // namespace placo::tools


### PR DESCRIPTION
The main difference is that now `Eigen::all` is `Eigen::placeholders::all`.